### PR TITLE
Add quiz item adjustment endpoints

### DIFF
--- a/src/docx/docx.controller.spec.ts
+++ b/src/docx/docx.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DocxController } from './docx.controller';
+import { DocxService } from './docx.service';
 
 describe('DocxController', () => {
   let controller: DocxController;
@@ -7,6 +8,7 @@ describe('DocxController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [DocxController],
+      providers: [DocxService],
     }).compile();
 
     controller = module.get<DocxController>(DocxController);

--- a/src/docx/gpt.controller.ts
+++ b/src/docx/gpt.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Post, Body } from '@nestjs/common';
-import { GptService } from './gpt.service';
+import { GptService, QuizItem } from './gpt.service';
 
 @Controller('gpt')
 export class GptController {
@@ -8,5 +8,15 @@ export class GptController {
     @Post('extract-quiz')
     async extractQuiz(@Body() body: { paragraphs: { paragraph: string; highlighted: { text: string; color: string }[] }[] }) {
         return this.gptService.extractQuizItems(body.paragraphs);
+    }
+
+    @Post('polish-quiz')
+    async polishQuiz(@Body() body: { item: QuizItem }) {
+        return this.gptService.polishQuizItem(body.item);
+    }
+
+    @Post('change-quiz-type')
+    async changeQuizType(@Body() body: { item: QuizItem; newType: QuizItem['type'] }) {
+        return this.gptService.changeQuizItemType(body.item, body.newType);
     }
 }

--- a/src/docx/gpt.service.spec.ts
+++ b/src/docx/gpt.service.spec.ts
@@ -1,0 +1,29 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigModule } from '@nestjs/config';
+import { GptService } from './gpt.service';
+
+describe('GptService', () => {
+  let service: GptService;
+
+  beforeEach(async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot()],
+      providers: [GptService],
+    }).compile();
+
+    service = module.get<GptService>(GptService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should have polishQuizItem function', () => {
+    expect(typeof service.polishQuizItem).toBe('function');
+  });
+
+  it('should have changeQuizItemType function', () => {
+    expect(typeof service.changeQuizItemType).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `polishQuizItem` and `changeQuizItemType` in `GptService`
- expose `/gpt/polish-quiz` and `/gpt/change-quiz-type` endpoints
- extend tests to cover new service and fix controller tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870f196c32c83249a3e36d02bbba657